### PR TITLE
Add NoNotImplementedError

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-openproject (0.3.0)
+    rubocop-openproject (0.4.0)
       rubocop
 
 GEM

--- a/config/default.yml
+++ b/config/default.yml
@@ -8,6 +8,11 @@ OpenProject/NoDoEndBlockWithRSpecCapybaraMatcherInExpect:
   Enabled: true
   VersionAdded: '0.1.0'
 
+OpenProject/NoNotImplementedError:
+  Description: 'Do not raise `NotImplementedError` to signal an unimplemented abstract method.'
+  Enabled: true
+  VersionAdded: '0.4.0'
+
 OpenProject/NoSleepInFeatureSpecs:
   Description: 'Avoid using `sleep` greater than 1 second in feature specs.'
   Enabled: true

--- a/lib/rubocop/cop/open_project/no_not_implemented_error.rb
+++ b/lib/rubocop/cop/open_project/no_not_implemented_error.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module OpenProject
+      # Warns against using a `NotImplementedError` exception when a method
+      # should be implemented by a subclass or including module. Ruby's
+      # `NotImplementedError` is reserved for platform-specific missing
+      # features (e.g., methods depending on `fsync` or `fork`), not for
+      # abstract method patterns.
+      #
+      # @example
+      #   # bad
+      #   raise NotImplementedError
+      #
+      #   # bad
+      #   raise NotImplementedError, "Subclasses must implement #foo"
+      #
+      #   # bad
+      #   raise NotImplementedError.new("Subclasses must implement #foo")
+      #
+      #   # bad
+      #   fail NotImplementedError
+      #
+      #   # good
+      #   raise NotYetImplementedError
+      #
+      #   # good
+      #   raise SubclassResponsibilityError, "#{self.class} must implement #foo"
+      #
+      class NoNotImplementedError < Base
+        MSG = "Do not raise `NotImplementedError` to signal an unimplemented abstract method. " \
+              "Ruby's `NotImplementedError` is reserved for platform-specific missing features. " \
+              "Raise a descriptive custom error class instead."
+
+        RESTRICT_ON_SEND = %i[raise fail].freeze
+
+        def_node_matcher :raises_not_implemented_error?, <<~PATTERN
+          {
+            (send nil? {:raise :fail} (const nil? :NotImplementedError) ...)
+            (send nil? {:raise :fail} (send (const nil? :NotImplementedError) :new ...) ...)
+          }
+        PATTERN
+
+        def on_send(node)
+          return unless raises_not_implemented_error?(node)
+
+          add_offense(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/open_project_cops.rb
+++ b/lib/rubocop/cop/open_project_cops.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "open_project/add_preview_for_view_component"
+require_relative "open_project/no_not_implemented_error"
 require_relative "open_project/use_service_result_factory_methods"
 require_relative "open_project/no_sleep_in_feature_specs"

--- a/lib/rubocop/open_project/version.rb
+++ b/lib/rubocop/open_project/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module OpenProject
-    VERSION = "0.3.0"
+    VERSION = "0.4.0"
   end
 end

--- a/spec/rubocop/cop/open_project/no_not_implemented_error_spec.rb
+++ b/spec/rubocop/cop/open_project/no_not_implemented_error_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::OpenProject::NoNotImplementedError, :config do
+  let(:config) { RuboCop::Config.new }
+
+  it "registers an offense when raising NotImplementedError" do
+    expect_offense(<<~RUBY)
+      raise NotImplementedError
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ OpenProject/NoNotImplementedError: #{described_class::MSG}
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it "registers an offense when raising NotImplementedError with a message argument" do
+    expect_offense(<<~RUBY)
+      raise NotImplementedError, "Subclasses must implement #foo"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ OpenProject/NoNotImplementedError: #{described_class::MSG}
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it "registers an offense when raising NotImplementedError.new" do
+    expect_offense(<<~RUBY)
+      raise NotImplementedError.new("Subclasses must implement #foo")
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ OpenProject/NoNotImplementedError: #{described_class::MSG}
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it "registers an offense when using the fail alias" do
+    expect_offense(<<~RUBY)
+      fail NotImplementedError
+      ^^^^^^^^^^^^^^^^^^^^^^^^ OpenProject/NoNotImplementedError: #{described_class::MSG}
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it "does not register an offense for other error classes" do
+    expect_no_offenses(<<~RUBY)
+      raise ArgumentError, "invalid argument"
+    RUBY
+  end
+
+  it "does not register an offense for a namespaced constant named NotImplementedError" do
+    expect_no_offenses(<<~RUBY)
+      raise MyModule::NotImplementedError
+    RUBY
+  end
+end


### PR DESCRIPTION
Following the discussion https://github.com/opf/openproject/pull/22520, adding a cop to advise against using `NotImplementedError`